### PR TITLE
fix: remove commented-out PostgreSQL configuration and unused logging…

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,14 +2,6 @@ name: ${APP_NAME:-qcon-web}
 
 services:
 
-  # postgresweb:
-  #   image: postgres
-  #   environment:
-  #     POSTGRES_PASSWORD: postgres
-  #     POSTGRES_DB: qcon-web
-  #   networks:
-  #     qcon-network:
-      
   app:
     image: qcon-web
     build: 
@@ -22,10 +14,6 @@ services:
       API_HOST: api.local
       API_PORT: 8000
       AUTOBAHN_USE_NVX: "0"
-      # POSTGRES_PASSWORD: postgres
-      # POSTGRES_HOST: localhost
-      # POSTGRES_DB: qcon-web
-      # POSTGRES_USER: postgres
       API_KEY: 01234567890
       DJANGO_SECRET_KEY: notveryS3cret
       APP_VERSION: 0.0.1
@@ -50,8 +38,6 @@ services:
       start_period: 40s
 
     depends_on:
-      # postgresweb:
-      #   condition: service_started
       frontend-builder:
         condition:  service_completed_successfully
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -2,14 +2,6 @@
 
 set -e
 
-# >&2 echo "make Database migrations"
-# python manage.py makemigrations frontend
-# echo "-------------------------------------------------------------------------------------------\n"
-
-# >&2 echo "Run Database migrations"
-# python manage.py migrate
-# echo "-------------------------------------------------------------------------------------------\n"
-
 >&2 echo "Collect static files"
 python manage.py collectstatic --noinput
 echo "-------------------------------------------------------------------------------------------\n"

--- a/qconweb/settings.py
+++ b/qconweb/settings.py
@@ -56,7 +56,7 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 SECRET_KEY = get_secret("DJANGO_SECRET_KEY", subdirectory='app-internal-credentials', required=True)
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = False
+DEBUG = os.getenv('DEBUG', False) == 'true'
 
 LOGGING_LEVEL = 'INFO'
 if DEBUG:
@@ -125,12 +125,6 @@ ASGI_APPLICATION = 'qconweb.asgi.application'
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.dummy'
-        # 'ENGINE': 'django.db.backends.postgresql',
-        # 'NAME': get_secret("POSTGRES_DB", subdirectory='db-credentials', required=True),
-        # 'USER': get_secret("POSTGRES_USER", subdirectory='db-credentials', required=True),
-        # 'PASSWORD': get_secret("POSTGRES_PASSWORD", subdirectory='db-credentials', required=True),
-        # 'HOST': POSTGRES_HOST,
-        # 'PORT': 5432,
     }
 }
 
@@ -186,11 +180,11 @@ MEDIA_ROOT = os.path.join(BASE_DIR, 'temp/')
 LOGGING = {
     'version': 1,
     'disable_existing_loggers': True,
-    'filters': {
-        'require_debug_true': {
-            '()': 'django.utils.log.RequireDebugTrue',
-        },
-    },
+    # 'filters': {
+    #     'require_debug_true': {
+    #         '()': 'django.utils.log.RequireDebugTrue',
+    #     },
+    # },
     'formatters': {
         'verbose': {
             'format':
@@ -212,14 +206,6 @@ LOGGING = {
             'level': LOGGING_LEVEL,
             'class': 'logging.StreamHandler',
             'formatter': 'custom'
-        },
-        'console_dev': {
-            'level': 'DEBUG',
-            'class': 'logging.handlers.RotatingFileHandler',
-            'filename': 'dev.log',
-            'formatter': 'custom',
-            'maxBytes': 1024 * 1024 * 10,  # 10 mb
-            'filters': ['require_debug_true']
         }
     },
     'loggers': {
@@ -229,7 +215,7 @@ LOGGING = {
             'propagate': False,
         },
         'frontend': {
-            'handlers': ['console','console_dev'],
+            'handlers': ['console'],
             'level': LOGGING_LEVEL,
             'propagate': False,
         },


### PR DESCRIPTION
… handlers

Removes all commented-out PostgreSQL database configuration from docker-compose.yml, docker-entrypoint.sh, and settings.py. Simplifies logging configuration by removing console_dev handler and require_debug_true filter. Makes DEBUG environment variable configurable via env var.

Closes issue #13 
