### PR TITLE
fix: websocket timeouts and large message handling (13MB+) with increased nginx timeouts, keepalive, and storage quota handling

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -17,25 +17,33 @@ Thumbs.db
 .github/
 
 # Python
-__pycache__
+__pycache__/
+**/__pycache__/
+**/__pycache__/**
 *.py[cod]
 *.pyo
 .Python
-env
-.venv
+env/
+.venv/
 
 # Node.js
-node_modules
+node_modules/
+**/node_modules/
+**/node_modules/**
+frontend/node_modules/
+frontend/node_modules/**
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 pnpm-debug.log*
 
 # Build outputs
-dist
-build
-out
-coverage
+dist/
+build/
+**/build/
+frontend/build/
+out/
+coverage/
 
 # Kubernetes / Helm artifacts
 charts/**/.tgz

--- a/conf.d/local.conf
+++ b/conf.d/local.conf
@@ -11,6 +11,10 @@ server {
 
     client_max_body_size 20M;
     root /var/www/html;
+    
+    # Connection limits (optional - adjust based on server capacity)
+    # limit_conn_zone $binary_remote_addr zone=conn_limit_per_ip:10m;
+    # limit_conn conn_limit_per_ip 10;  # Max 10 connections per IP
 
     location / {
         # checks for static file, if not found proxy to app
@@ -35,6 +39,11 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Host $server_name;
+
+        # WebSocket timeout settings - increased for large file processing
+        proxy_read_timeout 1800s;  # 30 minutes - allow long processing times
+        proxy_send_timeout 1800s;  # 30 minutes - allow long message transmission
+        proxy_connect_timeout 60s; # 1 minute - connection timeout
     }
 
 }

--- a/conf.d/nginx.conf
+++ b/conf.d/nginx.conf
@@ -11,6 +11,10 @@ server {
 
     client_max_body_size 20M;
     root /var/www/html;
+    
+    # Connection limits (optional - adjust based on server capacity)
+    # limit_conn_zone $binary_remote_addr zone=conn_limit_per_ip:10m;
+    # limit_conn conn_limit_per_ip 10;  # Max 10 connections per IP
 
     location / {
         # checks for static file, if not found proxy to app
@@ -34,6 +38,11 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Host $server_name;
+
+        # WebSocket timeout settings - increased for large file processing
+        proxy_read_timeout 1800s;  # 30 minutes - allow long processing times
+        proxy_send_timeout 1800s;  # 30 minutes - allow long message transmission
+        proxy_connect_timeout 60s; # 1 minute - connection timeout
     }
 
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,6 @@ name: ${APP_NAME:-qcon-web}
 services:
 
   app:
-    image: qcon-web
     build: 
       context: .
       args:

--- a/frontend/consumers.py
+++ b/frontend/consumers.py
@@ -13,10 +13,22 @@ class TextConsumer(AsyncJsonWebsocketConsumer):
     sessionid = None
     wssurl = None
     userip = None
+    processing_complete = False  # Track if processing is complete
 
     async def client(self):
+        # Configure websockets with increased timeouts for large messages
+        # max_size=None removes message size limit (be careful in production)
+        # ping_interval=30 keeps connection alive
+        # close_timeout=60 allows time for large messages to be sent
+        connect_kwargs = {
+            'max_size': None,  # Remove message size limit
+            'ping_interval': 30,  # Send ping every 30 seconds
+            'close_timeout': 60,  # Wait up to 60 seconds when closing
+            'read_limit': 2**30,  # 1GB read limit
+            'write_limit': 2**30,  # 1GB write limit
+        }
 
-        async with websockets.connect(self.wssurl) as websocket:
+        async with websockets.connect(self.wssurl, **connect_kwargs) as websocket:
             logger.info("Connected to api")
 
             await websocket.send(self.file_received)
@@ -24,45 +36,90 @@ class TextConsumer(AsyncJsonWebsocketConsumer):
             try:
                 async for message in websocket:
                     # Process message received on the connection.
-                    message = json.loads(message)
-                    # print(message)
-                    self.message_from_api = message
+                    try:
+                        message = json.loads(message)
+                        # print(message)
+                        self.message_from_api = message
 
-                    match message['status']:
-                        case "Busy":
-                            logger.info(f"status: {message['status']} message: {message['statustext']}")
-                            try:
+                        match message['status']:
+                            case "Busy":
+                                logger.info(f"status: {message['status']} message: {message['statustext']}")
+                                try:
+                                    await self.send(text_data=json.dumps(self.message_from_api))
+                                except Exception as e:
+                                    # await websocket.close()
+                                    logger.error(f"User closed the session: {e}")
+                                    # break
+                            case "Done":
+                                logger.info("status: Done")
+                                # Log message size for debugging
+                                message_str = json.dumps(self.message_from_api)
+                                message_size = len(message_str.encode('utf-8'))
+                                if message_size > 1024 * 1024:  # Log if > 1MB
+                                    logger.info(f"Sending large Done message: {message_size / 1024 / 1024:.2f}MB")
+                                
+                                try:
+                                    await self.send(text_data=message_str)
+                                    logger.info("Done message sent successfully to client")
+                                except Exception as e:
+                                    logger.error(f"Error sending Done message to client: {e}")
+                                    # Try to send error to client
+                                    error_message = {
+                                        'status': 'Error',
+                                        'statustext': f'Failed to send response: {str(e)}',
+                                        'hostname': message.get('hostname', ''),
+                                        'version': message.get('version', '')
+                                    }
+                                    await self.send(text_data=json.dumps(error_message))
+                            case "Close":
+                                logger.info("status: Close")
+                                logger.info("... closing connection to api")
+                                # Forward Close message to browser
+                                try:
+                                    await self.send(text_data=json.dumps(self.message_from_api))
+                                except Exception as e:
+                                    logger.error(f"Error sending Close message to client: {e}")
+                                # Mark processing as complete
+                                self.processing_complete = True
+                                break
+                            case "Error":
+                                logger.info("status: Error")
+                                logger.info("... closing connection to api because of an error")
                                 await self.send(text_data=json.dumps(self.message_from_api))
-                            except Exception as e:
-                                # await websocket.close()
-                                print(f" User closed the session: {e}")
-                                # break
-                        case "Done":
-                            logger.info("status: Done")
-                            await self.send(text_data=json.dumps(self.message_from_api))
-                        case "Close":
-                            logger.info("status: Close")
-                            logger.info("... closing connection to api")
-                            break
-                        case "Error":
-                            logger.info("status: Error")
-                            logger.info("... closing connection to api because of an error")
-                            await self.send(text_data=json.dumps(self.message_from_api))
-                            break
+                                break
+                    except json.JSONDecodeError as e:
+                        logger.error(f"Error decoding JSON message from API: {e}")
+                        logger.error(f"Message length: {len(message) if isinstance(message, str) else 'N/A'}")
+                    except Exception as e:
+                        logger.error(f"Error processing message from API: {e}")
                     
-            except websockets.ConnectionClosed:
-                logger.info("connection closed")
-                close_message = self.message_from_api
-                close_message['status'] = "Error"
-                close_message['statustext'] = "Connection to api lost!"
-                await self.send(text_data=json.dumps(close_message))
+            except websockets.ConnectionClosed as e:
+                logger.info(f"connection closed: {e}")
+                if hasattr(self, 'message_from_api') and self.message_from_api:
+                    close_message = self.message_from_api.copy()
+                    close_message['status'] = "Error"
+                    close_message['statustext'] = "Connection to api lost!"
+                else:
+                    close_message = {
+                        'status': "Error",
+                        'statustext': "Connection to api lost!",
+                        'hostname': '',
+                        'version': ''
+                    }
+                try:
+                    await self.send(text_data=json.dumps(close_message))
+                except:
+                    pass
                 logger.info("Connection to api lost!")
             except Exception as e:
-                logger.info(f'Other Exception: {e}')
+                logger.error(f'Other Exception: {e}')
+                import traceback
+                logger.error(traceback.format_exc())
 
     async def connect(self):
         self.sessionid = self.scope['session'].get('_csrftoken')
         # logger.info(self.scope['session'])
+        self.processing_complete = False  # Reset on new connection
 
         await self.accept()
         logger.info("user connected: " + str(self.sessionid))
@@ -76,25 +133,48 @@ class TextConsumer(AsyncJsonWebsocketConsumer):
         logger.info("user disconnected: " + str(self.sessionid))
 
     async def receive(self, text_data=None, bytes_data=None):
+        # If processing is already complete, ignore new messages (like keepalive pings)
+        if self.processing_complete:
+            logger.info("Ignoring message - processing already complete")
+            return
+        
         self.userip = self.scope['client'][0]
         logger.info(f"user ip: {self.userip}")
-        file_recieved = json.loads(text_data)
-        # Add IP to the user request
-        file_recieved["user_ip"] = str(self.userip)
-        # Convert back to json string
-        self.file_received = json.dumps(file_recieved)
-
-        self.wssurl = "wss://" + settings.API_HOST + '/ws'
-        if settings.DEBUG == True:
-            self.wssurl = "ws://" + settings.API_HOST + ":" + settings.API_PORT + '/ws'
-
-
-        logger.info("WSS URL: " + self.wssurl)
-
+        
         try:
-            await self.client()
-        except Exception as e:
-            logger.info("Error connecting: " + str(e))
+            file_recieved = json.loads(text_data)
+            # Check if this is a keepalive ping from the browser
+            if file_recieved.get('type') == 'ping':
+                logger.debug("Received keepalive ping from browser")
+                # Send pong response
+                await self.send(text_data=json.dumps({'type': 'pong'}))
+                return
+            
+            # Add IP to the user request
+            file_recieved["user_ip"] = str(self.userip)
+            # Convert back to json string
+            self.file_received = json.dumps(file_recieved)
+
+            self.wssurl = "wss://" + settings.API_HOST + '/ws'
+            if settings.DEBUG == True:
+                self.wssurl = "ws://" + settings.API_HOST + ":" + settings.API_PORT + '/ws'
+
+            logger.info("WSS URL: " + self.wssurl)
+
+            try:
+                await self.client()
+            except Exception as e:
+                logger.info("Error connecting: " + str(e))
+        except json.JSONDecodeError as e:
+            logger.error(f"Error parsing message from browser: {e}")
+            # Try to send error to browser
+            try:
+                await self.send(text_data=json.dumps({
+                    'status': 'Error',
+                    'statustext': 'Invalid message format'
+                }))
+            except:
+                pass
 
 
 


### PR DESCRIPTION
Closes issue #18 

## Changes
- **Nginx** (`conf.d/nginx.conf`, `conf.d/local.conf`): Increased timeouts to 30 minutes for websocket connections
- **Proxy Consumer** (`frontend/consumers.py`): Removed message size limits, added keepalive pings, better error handling
- **Client** (`frontend/src/App.jsx`): Added keepalive mechanism, async message processing, storage quota handling
